### PR TITLE
モバイルブラウザでスクロールアイコンがファーストビューに収まるよう修正

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -14,7 +14,7 @@ const ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
 
 export function Hero() {
   return (
-    <section className="relative min-h-screen flex flex-col items-center justify-center overflow-hidden">
+    <section className="relative min-h-dvh flex flex-col items-center justify-center overflow-hidden">
       {/* Animated gradient background */}
       <div className="absolute inset-0 bg-gradient-to-br from-indigo-500 via-purple-500 to-pink-500 bg-200% animate-gradient" />
 


### PR DESCRIPTION
## Summary
- Heroセクションの高さを`min-h-screen`(100vh)から`min-h-dvh`(100dvh)に変更
- モバイルブラウザのアドレスバーを考慮した動的なビューポート高さを使用

## 背景
Androidのchromeなどでは、ブラウザのURL領域があるため、100vhだとスクロールインジケーター（↓アイコン）がファーストビューに入らず、ユーザーがスクロールに気づかない可能性があった。

## Test plan
- [x] `npm run build` 成功
- [ ] モバイルブラウザでスクロールアイコンが見えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)